### PR TITLE
Add branch safety rule

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,16 @@
 # Repository Guidelines
 
+## Branch Safety Rules (CRITICAL)
+
+**NEVER make code changes directly on `main` branch.**
+
+Before making ANY code changes:
+1. Check current branch: `git branch --show-current`
+2. If on `main`, create a new branch IMMEDIATELY: `git checkout -b tm/jeffrey.schmitz2/jdi/{descriptive-name}`
+3. Only then proceed with edits
+
+This rule has NO exceptions. Even small fixes require a branch.
+
 ## Project Structure & Module Organization
 - `ios/` contains the native iOS app (SwiftUI + TCA). Open `ios/DemocracyDJ.xcodeproj` in Xcode.
 - `web/` is the React + TypeScript prototype (Vite + Tailwind). Source lives in `web/src/`, assets in `web/src/assets/`, and static files in `web/public/`.
@@ -27,6 +38,7 @@
 
 ## Commit & Pull Request Guidelines
 - Git history uses Conventional Commits (example: `chore: monorepo scaffold (ios, web, shared)`); follow that format.
+- Branch names should follow the pattern `tm/jeffrey.schmitz2/jdi/<short-description>`.
 - PRs should include a brief summary, the area touched (`ios`, `web`, `shared`), and screenshots for UI changes.
 - Link relevant issues or design docs from `docs/` when applicable.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,8 +76,10 @@ open ios/DemocracyDJ.xcodeproj   # Open in Xcode
 - Swift 6 strict concurrency
 
 ### Git
-- Conventional commits: `feat:`, `fix:`, `docs:`, `refactor:`, `chore:`
+- **NEVER commit to `main` directly** — always create a branch first
+- Before ANY code change: `git branch --show-current` → if on `main`, create branch immediately
 - Branch pattern: `tm/jeffrey.schmitz2/jdi/{descriptive-name}`
+- Conventional commits: `feat:`, `fix:`, `docs:`, `refactor:`, `chore:`
 
 ## Development Phases
 


### PR DESCRIPTION
## Summary
- Add **CRITICAL** branch safety rule to both `AGENTS.md` and `CLAUDE.md`
- Rule: NEVER make code changes directly on `main` — always create a branch first
- Applies to all AI agents (Claude Code, Codex, etc.)
- **Enabled GitHub branch protection on `main`**

## Changes
- `AGENTS.md`: Added "Branch Safety Rules" section at top
- `CLAUDE.md`: Added branch check rule to Git conventions

## Branch Protection Settings (via API)
- **Required status checks**: `Lint Web` must pass
- **Strict mode**: Branch must be up to date before merging
- **Force pushes**: Disabled
- **Branch deletion**: Disabled
- **PRs required**: Yes (0 approvals needed for solo dev)