### PR TITLE
chore: enable macos-26 CI jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
           xcodebuild -project DemocracyDJ.xcodeproj \
             -scheme DemocracyDJ \
             -sdk iphonesimulator \
-            -destination 'platform=iOS Simulator,name=iPhone 15' \
+            -destination 'platform=iOS Simulator,name=iPhone 17' \
             -skipMacroValidation \
             CODE_SIGN_IDENTITY="" \
             CODE_SIGNING_REQUIRED=NO \
@@ -55,7 +55,7 @@ jobs:
             xcodebuild -project DemocracyDJ.xcodeproj \
               -scheme DemocracyDJ \
               -sdk iphonesimulator \
-              -destination 'platform=iOS Simulator,name=iPhone 15' \
+              -destination 'platform=iOS Simulator,name=iPhone 17' \
               -skipMacroValidation \
               CODE_SIGN_IDENTITY="" \
               CODE_SIGNING_REQUIRED=NO \


### PR DESCRIPTION
## Summary
- enable build-ios and test-shared jobs on macos-26
- select Xcode 26.2 and add runner safeguards
- install iOS simulator runtime for iOS build

Refs: GitHub Actions macOS 26 preview runners.