### PR TITLE
chore(ci): add verbose toggle and optimize build times

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,7 +74,12 @@ jobs:
             ${{ runner.os }}-spm-
 
       - name: Install iOS Simulator Runtime
-        run: xcodebuild -downloadPlatform iOS
+        run: |
+          xcodebuild -downloadPlatform iOS || {
+            echo "Retrying simulator runtime download..."
+            sleep 10
+            xcodebuild -downloadPlatform iOS
+          }
 
       - name: Build iOS app (for testing)
         working-directory: ios


### PR DESCRIPTION
## Summary

Optimizes CI build times and adds a verbose logging toggle:

- **VERBOSE_BUILD toggle** - Set to `'true'` for debug output, `'false'` (default) for quiet builds
- **SPM caching** - Caches Swift Package Manager dependencies between runs
- **build-for-testing + test-without-building** - Eliminates redundant compilation (was building twice)
- **-quiet flag** - Suppresses verbose xcodebuild output when not debugging

## Expected Improvements

| Optimization | Estimated Savings |
|--------------|-------------------|
| SPM caching | 30-60s on cache hit |
| build-for-testing | 60-120s (no double build) |
| **Total** | **~2-3 minutes faster** |

## Usage

**Normal builds**: Just merge - quiet mode is the default.

**Debug a CI issue**: Change line 11 in ci.yml:
```yaml
VERBOSE_BUILD: 'true'
```

## Test Plan

- [ ] CI passes with quiet mode (default)
- [ ] Build time reduced vs previous runs
- [ ] SPM cache shows "Cache restored" on second run