### PR TITLE
feat(ios): add MultipeerClient dependency interface

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -250,7 +250,8 @@ playground.xcworkspace
 Carthage/Build/
 
 # Accio dependency management
-Dependencies/
+# Note: We keep ios/DemocracyDJ/Dependencies/ for our TCA dependencies
+/Dependencies/
 .accio/
 
 # fastlane

--- a/ios/DemocracyDJ.xcodeproj/project.pbxproj
+++ b/ios/DemocracyDJ.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 63;
+	objectVersion = 77;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -11,6 +11,7 @@
 		5B085BEF0AAA070285C57524 /* DemocracyDJApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 270D35D66AF0735BE4349F23 /* DemocracyDJApp.swift */; };
 		7BFA88A1A31D80452F444246 /* ComposableArchitecture in Frameworks */ = {isa = PBXBuildFile; productRef = E129185B905CD5A894646F07 /* ComposableArchitecture */; };
 		9ECD6A1784B80F6D08302F70 /* DemocracyDJTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A993AEE5104897B0F2112254 /* DemocracyDJTests.swift */; };
+		C6B272022FC0BF76ECE4BE7D /* MultipeerClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82FB9751896C9CA1E6D38FFC /* MultipeerClient.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -28,7 +29,7 @@
 		415F26E9ED70B4E94A51E291 /* DemocracyDJTests.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = DemocracyDJTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		632BF223B09E2B9022D00F4D /* shared */ = {isa = PBXFileReference; lastKnownFileType = folder; name = shared; path = ../shared; sourceTree = SOURCE_ROOT; };
 		7DCF23A7E45285B2398C02A6 /* DemocracyDJ.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = DemocracyDJ.app; sourceTree = BUILT_PRODUCTS_DIR; };
-		A827F4222F040B1200A011CA /* Shared.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = file; path = Shared.xctestplan; sourceTree = "<group>"; };
+		82FB9751896C9CA1E6D38FFC /* MultipeerClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MultipeerClient.swift; sourceTree = "<group>"; };
 		A993AEE5104897B0F2112254 /* DemocracyDJTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DemocracyDJTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -49,6 +50,7 @@
 			isa = PBXGroup;
 			children = (
 				A36C0A12B265779F339267EC /* App */,
+				9821EA7F469BAA8A8F9772A8 /* Dependencies */,
 			);
 			path = DemocracyDJ;
 			sourceTree = "<group>";
@@ -56,7 +58,6 @@
 		5F46DC02E77996D15018ED27 = {
 			isa = PBXGroup;
 			children = (
-				A827F4222F040B1200A011CA /* Shared.xctestplan */,
 				35833346B846C29BF03DF674 /* DemocracyDJ */,
 				763E5E192F12D91CD83EF7E7 /* DemocracyDJTests */,
 				79B6A649C68806695A2EAD48 /* Packages */,
@@ -89,12 +90,27 @@
 			name = Packages;
 			sourceTree = "<group>";
 		};
+		9821EA7F469BAA8A8F9772A8 /* Dependencies */ = {
+			isa = PBXGroup;
+			children = (
+				82FB9751896C9CA1E6D38FFC /* MultipeerClient.swift */,
+			);
+			path = Dependencies;
+			sourceTree = "<group>";
+		};
 		A36C0A12B265779F339267EC /* App */ = {
 			isa = PBXGroup;
 			children = (
 				270D35D66AF0735BE4349F23 /* DemocracyDJApp.swift */,
 			);
 			path = App;
+			sourceTree = "<group>";
+		};
+		"TEMP_8FF7ADB2-E0DE-4490-981C-D67F7BE0D70B" /* Features */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = Features;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -167,6 +183,7 @@
 				519D3338DDD06D3574FC56C1 /* XCRemoteSwiftPackageReference "swift-composable-architecture" */,
 				87BACAE3CA42FB44FAE202BD /* XCLocalSwiftPackageReference "../shared" */,
 			);
+			preferredProjectObjectVersion = 77;
 			projectDirPath = "";
 			projectRoot = "";
 			targets = (
@@ -182,6 +199,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				5B085BEF0AAA070285C57524 /* DemocracyDJApp.swift in Sources */,
+				C6B272022FC0BF76ECE4BE7D /* MultipeerClient.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ios/DemocracyDJ.xcodeproj/xcshareddata/xcschemes/DemocracyDJ.xcscheme
+++ b/ios/DemocracyDJ.xcodeproj/xcshareddata/xcschemes/DemocracyDJ.xcscheme
@@ -1,88 +1,120 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion="1620"
-   version="1.7">
+   LastUpgradeVersion = "1600"
+   version = "1.7">
    <BuildAction
-      parallelizeBuildables="YES"
-      buildImplicitDependencies="YES">
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES"
+      runPostActionsOnFailure = "NO">
       <BuildActionEntries>
          <BuildActionEntry
-            buildForTesting="YES"
-            buildForRunning="YES"
-            buildForProfiling="YES"
-            buildForArchiving="YES"
-            buildForAnalyzing="YES">
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
             <BuildableReference
-               BuildableIdentifier="primary"
-               BlueprintIdentifier="11803CCDED5EAD430AF862F1"
-               BuildableName="DemocracyDJ.app"
-               BlueprintName="DemocracyDJ"
-               ReferencedContainer="container:DemocracyDJ.xcodeproj">
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "11803CCDED5EAD430AF862F1"
+               BuildableName = "DemocracyDJ.app"
+               BlueprintName = "DemocracyDJ"
+               ReferencedContainer = "container:DemocracyDJ.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "NO"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "520127662CD1694D077A7589"
+               BuildableName = "DemocracyDJTests.xctest"
+               BlueprintName = "DemocracyDJTests"
+               ReferencedContainer = "container:DemocracyDJ.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
       </BuildActionEntries>
    </BuildAction>
    <TestAction
-      buildConfiguration="Debug"
-      selectedDebuggerIdentifier="Xcode.DebuggerFoundation.Debugger.LLDB"
-      selectedLauncherIdentifier="Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv="YES">
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      onlyGenerateCoverageForSpecifiedTargets = "NO">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "11803CCDED5EAD430AF862F1"
+            BuildableName = "DemocracyDJ.app"
+            BlueprintName = "DemocracyDJ"
+            ReferencedContainer = "container:DemocracyDJ.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
       <Testables>
          <TestableReference
-            skipped="NO">
+            skipped = "NO"
+            parallelizable = "NO">
             <BuildableReference
-               BuildableIdentifier="primary"
-               BlueprintIdentifier="520127662CD1694D077A7589"
-               BuildableName="DemocracyDJTests.xctest"
-               BlueprintName="DemocracyDJTests"
-               ReferencedContainer="container:DemocracyDJ.xcodeproj">
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "520127662CD1694D077A7589"
+               BuildableName = "DemocracyDJTests.xctest"
+               BlueprintName = "DemocracyDJTests"
+               ReferencedContainer = "container:DemocracyDJ.xcodeproj">
             </BuildableReference>
          </TestableReference>
       </Testables>
+      <CommandLineArguments>
+      </CommandLineArguments>
    </TestAction>
    <LaunchAction
-      buildConfiguration="Debug"
-      selectedDebuggerIdentifier="Xcode.DebuggerFoundation.Debugger.LLDB"
-      selectedLauncherIdentifier="Xcode.DebuggerFoundation.Launcher.LLDB"
-      launchStyle="0"
-      useCustomWorkingDirectory="NO"
-      ignoresPersistentStateOnLaunch="NO"
-      debugDocumentVersioning="YES"
-      debugServiceExtension="internal"
-      allowLocationSimulation="YES">
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
       <BuildableProductRunnable
-         runnableDebuggingMode="0">
+         runnableDebuggingMode = "0">
          <BuildableReference
-            BuildableIdentifier="primary"
-            BlueprintIdentifier="11803CCDED5EAD430AF862F1"
-            BuildableName="DemocracyDJ.app"
-            BlueprintName="DemocracyDJ"
-            ReferencedContainer="container:DemocracyDJ.xcodeproj">
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "11803CCDED5EAD430AF862F1"
+            BuildableName = "DemocracyDJ.app"
+            BlueprintName = "DemocracyDJ"
+            ReferencedContainer = "container:DemocracyDJ.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
+      <CommandLineArguments>
+      </CommandLineArguments>
    </LaunchAction>
    <ProfileAction
-      buildConfiguration="Release"
-      shouldUseLaunchSchemeArgsEnv="YES"
-      savedToolIdentifier=""
-      useCustomWorkingDirectory="NO"
-      debugDocumentVersioning="YES">
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
       <BuildableProductRunnable
-         runnableDebuggingMode="0">
+         runnableDebuggingMode = "0">
          <BuildableReference
-            BuildableIdentifier="primary"
-            BlueprintIdentifier="11803CCDED5EAD430AF862F1"
-            BuildableName="DemocracyDJ.app"
-            BlueprintName="DemocracyDJ"
-            ReferencedContainer="container:DemocracyDJ.xcodeproj">
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "11803CCDED5EAD430AF862F1"
+            BuildableName = "DemocracyDJ.app"
+            BlueprintName = "DemocracyDJ"
+            ReferencedContainer = "container:DemocracyDJ.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
+      <CommandLineArguments>
+      </CommandLineArguments>
    </ProfileAction>
    <AnalyzeAction
-      buildConfiguration="Debug">
+      buildConfiguration = "Debug">
    </AnalyzeAction>
    <ArchiveAction
-      buildConfiguration="Release"
-      revealArchiveInOrganizer="YES">
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
    </ArchiveAction>
 </Scheme>

--- a/ios/DemocracyDJ/Dependencies/MultipeerClient.swift
+++ b/ios/DemocracyDJ/Dependencies/MultipeerClient.swift
@@ -1,0 +1,97 @@
+import Dependencies
+import Shared
+
+// MARK: - MultipeerClient
+
+/// TCA dependency for mesh networking. Abstracts MultipeerConnectivity.
+/// MCPeerID never escapes this interface—all domain code uses `Peer`.
+struct MultipeerClient: Sendable {
+    /// Start advertising as host with the given display name.
+    var startHosting: @Sendable (_ displayName: String) async -> Void
+
+    /// Start browsing for hosts with the given display name.
+    var startBrowsing: @Sendable (_ displayName: String) async -> Void
+
+    /// Stop all networking activity (advertising, browsing, session).
+    var stop: @Sendable () async -> Void
+
+    /// Sends a message to a specific peer, or broadcasts to all peers when `to == nil`.
+    var send: @Sendable (_ message: MeshMessage, _ to: Peer?) async throws -> Void
+
+    /// Returns a stream of networking events. Subscribe once per feature lifecycle.
+    var events: @Sendable () -> AsyncStream<MultipeerEvent>
+}
+
+// MARK: - MultipeerEvent
+
+/// Events emitted by the multipeer networking layer.
+/// These are the only networking events that TCA reducers see.
+enum MultipeerEvent: Sendable, Equatable {
+    /// A peer was discovered during browsing (not yet connected).
+    case peerDiscovered(Peer)
+
+    /// A peer successfully connected to the session.
+    case peerConnected(Peer)
+
+    /// A peer disconnected from the session.
+    case peerDisconnected(Peer)
+
+    /// A message was received from a connected peer.
+    case messageReceived(MeshMessage, from: Peer)
+}
+
+// MARK: - DependencyKey
+
+extension MultipeerClient: DependencyKey {
+    static let liveValue: MultipeerClient = .live
+    static let testValue: MultipeerClient = .mock
+    static let previewValue: MultipeerClient = .preview
+}
+
+extension DependencyValues {
+    var multipeerClient: MultipeerClient {
+        get { self[MultipeerClient.self] }
+        set { self[MultipeerClient.self] = newValue }
+    }
+}
+
+// MARK: - Stub Implementations
+
+extension MultipeerClient {
+    /// Placeholder for "Implement MultipeerClient Live Dependency" issue.
+    /// Will be replaced with actual MultipeerConnectivity implementation.
+    static let live = MultipeerClient(
+        startHosting: { _ in },
+        startBrowsing: { _ in },
+        stop: { },
+        send: { _, _ in },
+        events: {
+            // Never-finishing stream (like real networking)
+            AsyncStream { _ in }
+        }
+    )
+
+    /// No-op for unit tests. Never yields events, never finishes.
+    /// Tests needing events should override via withDependencies.
+    static let mock = MultipeerClient(
+        startHosting: { _ in },
+        startBrowsing: { _ in },
+        stop: { },
+        send: { _, _ in },
+        events: {
+            // Never-finishing stream - avoids "stream ended" surprises
+            AsyncStream { _ in }
+        }
+    )
+
+    /// For SwiftUI previews. Will be enhanced in "Create Mock MultipeerClient" issue.
+    static let preview = MultipeerClient(
+        startHosting: { _ in },
+        startBrowsing: { _ in },
+        stop: { },
+        send: { _, _ in },
+        events: {
+            AsyncStream { _ in }
+        }
+    )
+}

--- a/ios/project.yml
+++ b/ios/project.yml
@@ -58,3 +58,22 @@ targets:
         GENERATE_INFOPLIST_FILE: YES
     dependencies:
       - target: DemocracyDJ
+
+schemes:
+  DemocracyDJ:
+    build:
+      targets:
+        DemocracyDJ: all
+        DemocracyDJTests: [test]
+    run:
+      config: Debug
+    test:
+      config: Debug
+      targets:
+        - DemocracyDJTests
+    profile:
+      config: Release
+    analyze:
+      config: Debug
+    archive:
+      config: Release

--- a/shared/Sources/Shared/DemocracyModels.swift
+++ b/shared/Sources/Shared/DemocracyModels.swift
@@ -59,7 +59,7 @@ public struct QueueItem: Identifiable, Equatable, Codable, Sendable {
 
 /// The top-level wrapper for all communication over the Mesh Network.
 /// This ensures strict typing when decoding data streams.
-public enum MeshMessage: Codable, Sendable {
+public enum MeshMessage: Equatable, Codable, Sendable {
     /// Sent by Guest -> Host
     /// "I want to do something"
     case intent(GuestIntent)
@@ -70,7 +70,7 @@ public enum MeshMessage: Codable, Sendable {
 }
 
 /// Actions a Guest can take.
-public enum GuestIntent: Codable, Sendable {
+public enum GuestIntent: Equatable, Codable, Sendable {
     /// "I found this song on Apple Music, please add it."
     case suggestSong(Song)
 
@@ -79,7 +79,7 @@ public enum GuestIntent: Codable, Sendable {
 }
 
 /// The "Source of Truth" broadcasted by the Host.
-public struct HostSnapshot: Codable, Sendable {
+public struct HostSnapshot: Equatable, Codable, Sendable {
     public let nowPlaying: Song?
     public let queue: [QueueItem] // Already sorted by votes
     public let connectedPeers: [Peer]


### PR DESCRIPTION
## Summary

Implements Issue #6: Define the TCA dependency interface for MultipeerConnectivity.

**This is the contract only** - no actual MultipeerConnectivity implementation (that's Issue #7).

## What's Added

### MultipeerClient struct
```swift
struct MultipeerClient: Sendable {
    var startHosting: @Sendable (_ displayName: String) async -> Void
    var startBrowsing: @Sendable (_ displayName: String) async -> Void
    var stop: @Sendable () async -> Void
    var send: @Sendable (_ message: MeshMessage, _ to: Peer?) async throws -> Void
    var events: @Sendable () -> AsyncStream<MultipeerEvent>
}
```

### MultipeerEvent enum
```swift
enum MultipeerEvent: Sendable, Equatable {
    case peerDiscovered(Peer)
    case peerConnected(Peer)
    case peerDisconnected(Peer)
    case messageReceived(MeshMessage, from: Peer)
}
```

### DependencyKey conformance
- `.liveValue` - placeholder for Issue #7
- `.testValue` - no-op mock for unit tests
- `.previewValue` - for SwiftUI previews

## Key Design Decisions

1. **Never-finishing streams** - Stubs use `AsyncStream { _ in }` (never finishes) to mimic real networking behavior and avoid "stream ended" surprises in tests
2. **Doc comments** - All methods documented with semantics (`to == nil` = broadcast, subscribe once per lifecycle)
3. **No MCPeerID** - Interface uses only `Peer` and `MeshMessage` from Shared package

## Acceptance Criteria

- [x] `MultipeerClient` struct defined with all methods
- [x] `MultipeerEvent` enum defined with all cases
- [x] `DependencyKey` conformance compiles
- [x] `.testValue` returns a no-op mock
- [x] Interface uses ONLY `Shared` types (`Peer`, `MeshMessage`)
- [x] `MCPeerID` does not appear anywhere in this file

## Also Fixed

- `.gitignore` was blocking `Dependencies/` folder - now allows `ios/DemocracyDJ/Dependencies/`

Closes #6