### PR TITLE
Add CI bypass toggle

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,13 +39,12 @@ on:
 env:
   # Toggle verbose logging: 'true' for debug output, 'false' for quiet builds
   VERBOSE_BUILD: ${{ inputs.verbose || 'false' }}
-  BYPASS_CI: ${{ inputs.bypass_ci || 'true' }}
 
 jobs:
   changes:
     name: Detect changes
     runs-on: ubuntu-latest
-    if: env.BYPASS_CI != 'true'
+    if: ${{ github.event_name == 'workflow_dispatch' && inputs.bypass_ci != 'true' }}
     outputs:
       web: ${{ steps.filter.outputs.web }}
       ios: ${{ steps.filter.outputs.ios }}
@@ -68,7 +67,7 @@ jobs:
     runs-on: macos-26
     timeout-minutes: 30
     needs: changes
-    if: env.BYPASS_CI != 'true' && (needs.changes.outputs.ios == 'true' || needs.changes.outputs.shared == 'true' || inputs.force_ios == 'true') && inputs.disable_ios != 'true'
+    if: ${{ github.event_name == 'workflow_dispatch' && inputs.bypass_ci != 'true' && (needs.changes.outputs.ios == 'true' || needs.changes.outputs.shared == 'true' || inputs.force_ios == 'true') && inputs.disable_ios != 'true' }}
     env:
       DERIVED_DATA_PATH: ~/Library/Developer/Xcode/DerivedData/DemocracyDJ-CI
     steps:
@@ -130,7 +129,7 @@ jobs:
     runs-on: macos-26
     timeout-minutes: 15
     needs: changes
-    if: env.BYPASS_CI != 'true' && (needs.changes.outputs.shared == 'true' || inputs.force_shared == 'true')
+    if: ${{ github.event_name == 'workflow_dispatch' && inputs.bypass_ci != 'true' && (needs.changes.outputs.shared == 'true' || inputs.force_shared == 'true') }}
     steps:
       - uses: actions/checkout@v4
 
@@ -165,7 +164,7 @@ jobs:
     name: Lint Web
     runs-on: ubuntu-latest
     needs: changes
-    if: env.BYPASS_CI != 'true' && (needs.changes.outputs.web == 'true' || inputs.force_web == 'true')
+    if: ${{ github.event_name == 'workflow_dispatch' && inputs.bypass_ci != 'true' && (needs.changes.outputs.web == 'true' || inputs.force_web == 'true') }}
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
## Summary
- add  input to skip all CI jobs
- re-enable iOS build job with bypass gating
- gate Shared and Web jobs behind the bypass flag

Use  to skip CI entirely.