### PR TITLE
feat(ios): add GuestFeature reducer with tests

### DIFF
--- a/ios/DemocracyDJ.xcodeproj/project.pbxproj
+++ b/ios/DemocracyDJ.xcodeproj/project.pbxproj
@@ -11,8 +11,10 @@
 		5B085BEF0AAA070285C57524 /* DemocracyDJApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 270D35D66AF0735BE4349F23 /* DemocracyDJApp.swift */; };
 		6AA2C7F62E2E3AF4AFB831A1 /* HostFeature.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E3D87C2C3A9D6F1D4CE9C5A /* HostFeature.swift */; };
 		3C6D8F2A1B4E7C9D0F1A2B3C /* HostView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A0B2E4C1F8A4F3D9E6B2C1A /* HostView.swift */; };
+		4D2C1B0A9F8E7D6C5B4A3928 /* GuestFeature.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C4A7F1B2D3E4F5061728394 /* GuestFeature.swift */; };
 		7BFA88A1A31D80452F444246 /* ComposableArchitecture in Frameworks */ = {isa = PBXBuildFile; productRef = E129185B905CD5A894646F07 /* ComposableArchitecture */; };
 		9ECD6A1784B80F6D08302F70 /* DemocracyDJTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A993AEE5104897B0F2112254 /* DemocracyDJTests.swift */; };
+		A1B2C3D4E5F60718293A4B5C /* GuestFeatureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E0F1A2B3C4D5E6F7081920A /* GuestFeatureTests.swift */; };
 		B4E1B47C2D0D8F5C6B6C3F9A /* HostFeatureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D91A4F2B0B2C5F88E0A7D6C /* HostFeatureTests.swift */; };
 		BF16B469E96A34ADD73E97BE /* MultipeerClient+Live.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5A2CA4BCE543BE2CEEF4F8E /* MultipeerClient+Live.swift */; };
 		C6B272022FC0BF76ECE4BE7D /* MultipeerClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82FB9751896C9CA1E6D38FFC /* MultipeerClient.swift */; };
@@ -31,6 +33,7 @@
 /* Begin PBXFileReference section */
 		1E3D87C2C3A9D6F1D4CE9C5A /* HostFeature.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HostFeature.swift; sourceTree = "<group>"; };
 		7A0B2E4C1F8A4F3D9E6B2C1A /* HostView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HostView.swift; sourceTree = "<group>"; };
+		8C4A7F1B2D3E4F5061728394 /* GuestFeature.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GuestFeature.swift; sourceTree = "<group>"; };
 		2D91A4F2B0B2C5F88E0A7D6C /* HostFeatureTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HostFeatureTests.swift; sourceTree = "<group>"; };
 		270D35D66AF0735BE4349F23 /* DemocracyDJApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DemocracyDJApp.swift; sourceTree = "<group>"; };
 		3F18D2C0F9A1B2C3D4E5F678 /* DemocracyDJTests.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = file; path = DemocracyDJTests.xctestplan; sourceTree = "<group>"; };
@@ -40,6 +43,7 @@
 		7DCF23A7E45285B2398C02A6 /* DemocracyDJ.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = DemocracyDJ.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		82FB9751896C9CA1E6D38FFC /* MultipeerClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MultipeerClient.swift; sourceTree = "<group>"; };
 		A993AEE5104897B0F2112254 /* DemocracyDJTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DemocracyDJTests.swift; sourceTree = "<group>"; };
+		9E0F1A2B3C4D5E6F7081920A /* GuestFeatureTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GuestFeatureTests.swift; sourceTree = "<group>"; };
 		F5A2CA4BCE543BE2CEEF4F8E /* MultipeerClient+Live.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MultipeerClient+Live.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -92,6 +96,7 @@
 			children = (
 				A993AEE5104897B0F2112254 /* DemocracyDJTests.swift */,
 				2D91A4F2B0B2C5F88E0A7D6C /* HostFeatureTests.swift */,
+				9E0F1A2B3C4D5E6F7081920A /* GuestFeatureTests.swift */,
 			);
 			path = DemocracyDJTests;
 			sourceTree = "<group>";
@@ -125,8 +130,17 @@
 			isa = PBXGroup;
 			children = (
 				7D4F2C87A8F0D2E1B5F9A1C3 /* Host */,
+				6F5E4D3C2B1A090807060504 /* Guest */,
 			);
 			path = Features;
+			sourceTree = "<group>";
+		};
+		6F5E4D3C2B1A090807060504 /* Guest */ = {
+			isa = PBXGroup;
+			children = (
+				8C4A7F1B2D3E4F5061728394 /* GuestFeature.swift */,
+			);
+			path = Guest;
 			sourceTree = "<group>";
 		};
 		7D4F2C87A8F0D2E1B5F9A1C3 /* Host */ = {
@@ -226,6 +240,7 @@
 				5B085BEF0AAA070285C57524 /* DemocracyDJApp.swift in Sources */,
 				6AA2C7F62E2E3AF4AFB831A1 /* HostFeature.swift in Sources */,
 				3C6D8F2A1B4E7C9D0F1A2B3C /* HostView.swift in Sources */,
+				4D2C1B0A9F8E7D6C5B4A3928 /* GuestFeature.swift in Sources */,
 				BF16B469E96A34ADD73E97BE /* MultipeerClient+Live.swift in Sources */,
 				C6B272022FC0BF76ECE4BE7D /* MultipeerClient.swift in Sources */,
 			);
@@ -237,6 +252,7 @@
 			files = (
 				9ECD6A1784B80F6D08302F70 /* DemocracyDJTests.swift in Sources */,
 				B4E1B47C2D0D8F5C6B6C3F9A /* HostFeatureTests.swift in Sources */,
+				A1B2C3D4E5F60718293A4B5C /* GuestFeatureTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ios/DemocracyDJ/Features/Guest/GuestFeature.swift
+++ b/ios/DemocracyDJ/Features/Guest/GuestFeature.swift
@@ -1,0 +1,166 @@
+import ComposableArchitecture
+import Foundation
+import Shared
+
+@Reducer
+struct GuestFeature {
+    @ObservableState
+    struct State: Equatable {
+        /// Local peer identity owned by this reducer.
+        /// Created on startBrowsing; never inferred from network events.
+        var myPeer: Peer?
+
+        var connectionStatus: ConnectionStatus = .disconnected
+        var hostSnapshot: HostSnapshot?
+        var pendingVotes: Set<String> = []
+        var availableHosts: IdentifiedArrayOf<Peer> = []
+
+        enum ConnectionStatus: Equatable {
+            case disconnected
+            case browsing
+            case connecting(host: Peer)
+            case connected(host: Peer)
+            case failed(reason: String)
+        }
+    }
+
+    enum Action {
+        // MARK: - Lifecycle
+        case startBrowsing(displayName: String)
+        case stopBrowsing
+        case connectToHost(Peer)
+
+        // MARK: - User Actions
+        case voteTapped(songID: String)
+        case suggestSongTapped(Song)
+
+        // MARK: - Network
+        case multipeerEvent(MultipeerEvent)
+
+        // MARK: - Internal
+        case _snapshotReceived(HostSnapshot)
+        case _connectionFailed(String)
+    }
+
+    @Dependency(\.multipeerClient) var multipeerClient
+    @Dependency(\.uuid) var uuid
+
+    var body: some ReducerOf<Self> {
+        Reduce { state, action in
+            switch action {
+
+            // MARK: - Lifecycle
+
+            case let .startBrowsing(displayName):
+                state.myPeer = Peer(
+                    id: uuid().uuidString,
+                    name: displayName
+                )
+                state.connectionStatus = .browsing
+                state.availableHosts.removeAll()
+                state.hostSnapshot = nil
+                state.pendingVotes.removeAll()
+
+                return .run { send in
+                    await multipeerClient.startBrowsing(displayName)
+                    for await event in multipeerClient.events() {
+                        await send(.multipeerEvent(event))
+                    }
+                }
+
+            case .stopBrowsing:
+                state.connectionStatus = .disconnected
+                state.availableHosts.removeAll()
+                state.hostSnapshot = nil
+                state.pendingVotes.removeAll()
+
+                return .run { _ in
+                    await multipeerClient.stop()
+                }
+
+            case let .connectToHost(host):
+                state.connectionStatus = .connecting(host: host)
+
+                return .run { send in
+                    do {
+                        try await multipeerClient.invite(host)
+                    } catch {
+                        await send(._connectionFailed("Connection failed"))
+                    }
+                }
+
+            case let ._connectionFailed(reason):
+                state.connectionStatus = .failed(reason: reason)
+                return .none
+
+            // MARK: - User Actions
+
+            case let .voteTapped(songID):
+                guard case let .connected(host) = state.connectionStatus else {
+                    return .none
+                }
+
+                // Optimistic UI: record vote immediately
+                state.pendingVotes.insert(songID)
+
+                return .run { _ in
+                    let intent = GuestIntent.vote(songID: songID)
+                    let message = MeshMessage.intent(intent)
+                    try await multipeerClient.send(message, host)
+                }
+
+            case let .suggestSongTapped(song):
+                guard case let .connected(host) = state.connectionStatus else {
+                    return .none
+                }
+
+                return .run { _ in
+                    let intent = GuestIntent.suggestSong(song)
+                    let message = MeshMessage.intent(intent)
+                    try await multipeerClient.send(message, host)
+                }
+
+            // MARK: - Network Events
+
+            case let .multipeerEvent(event):
+                switch event {
+
+                case let .peerDiscovered(peer):
+                    if !state.availableHosts.contains(peer) {
+                        state.availableHosts.append(peer)
+                    }
+                    return .none
+
+                case let .peerConnected(peer):
+                    if case .connecting = state.connectionStatus {
+                        state.connectionStatus = .connected(host: peer)
+                        state.availableHosts.removeAll()
+                    }
+                    return .none
+
+                case .peerDisconnected:
+                    state.connectionStatus = .disconnected
+                    state.hostSnapshot = nil
+                    state.pendingVotes.removeAll()
+                    return .none
+
+                case let .messageReceived(message, _):
+                    switch message {
+                    case let .stateUpdate(snapshot):
+                        return .send(._snapshotReceived(snapshot))
+                    case .intent:
+                        // Guests never process intents
+                        return .none
+                    }
+                }
+
+            // MARK: - Internal
+
+            case let ._snapshotReceived(snapshot):
+                state.hostSnapshot = snapshot
+                state.pendingVotes.removeAll()
+                return .none
+            }
+        }
+    }
+}

--- a/ios/DemocracyDJTests/GuestFeatureTests.swift
+++ b/ios/DemocracyDJTests/GuestFeatureTests.swift
@@ -1,0 +1,179 @@
+import ComposableArchitecture
+import Foundation
+import Shared
+import Testing
+@testable import DemocracyDJ
+
+@MainActor
+@Suite("GuestFeature")
+struct GuestFeatureTests {
+    @Test func startBrowsingCreatesLocalPeer() async {
+        let recorder = GuestStartRecorder()
+        let store = TestStore(initialState: GuestFeature.State()) {
+            GuestFeature()
+        } withDependencies: {
+            $0.multipeerClient = .mock(
+                events: AsyncStream { $0.finish() },
+                onStartBrowsing: { displayName in
+                    await recorder.record(name: displayName)
+                }
+            )
+            $0.uuid = .incrementing
+        }
+
+        await store.send(.startBrowsing(displayName: "Guest")) {
+            $0.myPeer = Peer(id: UUID(0).uuidString, name: "Guest")
+            $0.connectionStatus = .browsing
+            $0.availableHosts = []
+            $0.hostSnapshot = nil
+            $0.pendingVotes = []
+        }
+
+        #expect(store.state.connectionStatus == .browsing)
+        #expect(store.state.availableHosts.isEmpty)
+        #expect(store.state.hostSnapshot == nil)
+        #expect(store.state.pendingVotes.isEmpty)
+        #expect(store.state.myPeer?.name == "Guest")
+
+        let startedName = await recorder.name
+        #expect(startedName == "Guest")
+
+        await store.finish()
+    }
+
+    @Test func voteTappedSendsIntentAndTracksPending() async {
+        let host = Peer(id: "host", name: "Host")
+        let recorder = GuestSendRecorder()
+        let songID = "song-1"
+
+        let store = TestStore(initialState: GuestFeature.State(
+            myPeer: Peer(id: "guest", name: "Guest"),
+            connectionStatus: .connected(host: host)
+        )) {
+            GuestFeature()
+        } withDependencies: {
+            $0.multipeerClient = .mock(
+                onSend: { message, target in
+                    await recorder.record(message: message, target: target)
+                }
+            )
+        }
+
+        await store.send(.voteTapped(songID: songID)) {
+            $0.pendingVotes = [songID]
+        }
+
+        await recorder.waitForCount(1)
+        let record = await recorder.last
+        #expect(record?.message == .intent(.vote(songID: songID)))
+        #expect(record?.target == host)
+    }
+
+    @Test func snapshotReceivedClearsPendingVotes() async {
+        let snapshot = HostSnapshot(nowPlaying: nil, queue: [], connectedPeers: [])
+        let store = TestStore(initialState: GuestFeature.State(
+            myPeer: Peer(id: "guest", name: "Guest"),
+            hostSnapshot: nil,
+            pendingVotes: ["song-1"]
+        )) {
+            GuestFeature()
+        }
+
+        await store.send(GuestFeature.Action._snapshotReceived(snapshot)) {
+            $0.hostSnapshot = snapshot
+            $0.pendingVotes = []
+        }
+    }
+
+    @Test func peerDiscoveryUpdatesAvailableHosts() async {
+        let host = Peer(id: "host", name: "Host")
+        let store = TestStore(initialState: GuestFeature.State()) {
+            GuestFeature()
+        }
+
+        await store.send(.multipeerEvent(.peerDiscovered(host))) {
+            $0.availableHosts.append(host)
+        }
+
+        await store.send(.multipeerEvent(.peerDiscovered(host)))
+        #expect(store.state.availableHosts.count == 1)
+    }
+
+    @Test func connectToHostInvites() async {
+        let host = Peer(id: "host", name: "Host")
+        let recorder = InviteRecorder()
+
+        let store = TestStore(initialState: GuestFeature.State()) {
+            GuestFeature()
+        } withDependencies: {
+            $0.multipeerClient = .mock(
+                onInvite: { peer in
+                    await recorder.record(peer: peer)
+                }
+            )
+        }
+
+        await store.send(.connectToHost(host)) {
+            $0.connectionStatus = .connecting(host: host)
+        }
+
+        await recorder.waitForCount(1)
+        let last = await recorder.last
+        #expect(last == host)
+    }
+}
+
+actor GuestSendRecorder {
+    struct Record: Equatable {
+        let message: MeshMessage
+        let target: Peer?
+    }
+
+    private var records: [Record] = []
+
+    func record(message: MeshMessage, target: Peer?) {
+        records.append(Record(message: message, target: target))
+    }
+
+    func waitForCount(_ count: Int) async {
+        for _ in 0..<100 {
+            if records.count >= count {
+                return
+            }
+            try? await Task.sleep(for: .milliseconds(10))
+        }
+    }
+
+    var last: Record? {
+        records.last
+    }
+}
+
+actor GuestStartRecorder {
+    private(set) var name: String?
+
+    func record(name: String) {
+        self.name = name
+    }
+}
+
+actor InviteRecorder {
+    private var peers: [Peer] = []
+
+    func record(peer: Peer) {
+        peers.append(peer)
+    }
+
+    func waitForCount(_ count: Int) async {
+        for _ in 0..<100 {
+            if peers.count >= count {
+                return
+            }
+            try? await Task.sleep(for: .milliseconds(10))
+        }
+    }
+
+    var last: Peer? {
+        peers.last
+    }
+}


### PR DESCRIPTION
## Summary
- Add GuestFeature reducer for passenger/guest role
- Add MultipeerClient invite method for explicit host connection
- Add comprehensive tests using PointFree TCA patterns

## Test plan
- [x] All GuestFeatureTests pass locally
- [x] Uses `.incrementing` UUID pattern per PointFree conventions

Closes #11