### PR TITLE
Wire MusicKitClient into HostFeature

### DIFF
--- a/ios/DemocracyDJ/Features/Host/HostFeature.swift
+++ b/ios/DemocracyDJ/Features/Host/HostFeature.swift
@@ -62,6 +62,7 @@ struct HostFeature {
     }
 
     @Dependency(\.multipeerClient) private var multipeerClient
+    @Dependency(\.musicKitClient) private var musicKitClient
 
     private enum CancelID {
         case multipeerEvents
@@ -69,6 +70,7 @@ struct HostFeature {
 
     var body: some ReducerOf<Self> {
         Reduce { state, action in
+            _ = musicKitClient
             var effects: [Effect<Action>] = []
             var needsBroadcast = false
 


### PR DESCRIPTION
## Summary
- inject MusicKitClient into HostFeature
- keep dependency unused (no actions/logic added)

Refs #47.