### PR TITLE
Host error handling and alerts

### DIFF
--- a/ios/DemocracyDJ/Features/Host/HostView.swift
+++ b/ios/DemocracyDJ/Features/Host/HostView.swift
@@ -324,6 +324,7 @@ struct HostView: View {
                 }
             }
         }
+        .alert($store.scope(state: \.alert, action: \.alert))
     }
 
     private var statusLabel: String {


### PR DESCRIPTION
## Summary
- add alert state and open settings handling for host errors
- surface playback and search failures with user-facing alerts
- log broadcast send failures and add test coverage

Closes #60.