### PR TITLE
HostView album artwork

### DIFF
--- a/ios/DemocracyDJ.xcodeproj/project.pbxproj
+++ b/ios/DemocracyDJ.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		3C6D8F2A1B4E7C9D0F1A2B3C /* HostView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A0B2E4C1F8A4F3D9E6B2C1A /* HostView.swift */; };
+		C1D2E3F405162738495A6B7C /* AlbumArtworkView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1A2C3D4E5F60718293A4B6C /* AlbumArtworkView.swift */; };
 		4D2C1B0A9F8E7D6C5B4A3928 /* GuestFeature.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C4A7F1B2D3E4F5061728394 /* GuestFeature.swift */; };
 		52D09770ADE9BD3F462D6740 /* Shared in Frameworks */ = {isa = PBXBuildFile; productRef = A5444B95CCD439271AAF0C92 /* Shared */; };
 		5B085BEF0AAA070285C57524 /* DemocracyDJApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 270D35D66AF0735BE4349F23 /* DemocracyDJApp.swift */; };
@@ -48,6 +49,7 @@
 		3F18D2C0F9A1B2C3D4E5F678 /* DemocracyDJTests.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = DemocracyDJTests.xctestplan; sourceTree = "<group>"; };
 		415F26E9ED70B4E94A51E291 /* DemocracyDJTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = DemocracyDJTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		4D5E6F7081920A1B2C3D4E5F /* AppView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppView.swift; sourceTree = "<group>"; };
+		B1A2C3D4E5F60718293A4B6C /* AlbumArtworkView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlbumArtworkView.swift; sourceTree = "<group>"; };
 		632BF223B09E2B9022D00F4D /* shared */ = {isa = PBXFileReference; lastKnownFileType = folder; name = shared; path = ../shared; sourceTree = SOURCE_ROOT; };
 		665D74033AE5AC105B0C44DB /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		6B7C8D9E0F1A2B3C4D5E6F70 /* MusicKitClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MusicKitClient.swift; sourceTree = "<group>"; };
@@ -80,6 +82,7 @@
 				665D74033AE5AC105B0C44DB /* Info.plist */,
 				A36C0A12B265779F339267EC /* App */,
 				A7F1B2C3D4E5F60718293A4B /* Features */,
+				D1E2F3A405162738495A6B7C /* Views */,
 				9821EA7F469BAA8A8F9772A8 /* Dependencies */,
 				A879A8182F083733006E069A /* Assets.xcassets */,
 			);
@@ -151,6 +154,14 @@
 				7A0B2E4C1F8A4F3D9E6B2C1A /* HostView.swift */,
 			);
 			path = Host;
+			sourceTree = "<group>";
+		};
+		D1E2F3A405162738495A6B7C /* Views */ = {
+			isa = PBXGroup;
+			children = (
+				B1A2C3D4E5F60718293A4B6C /* AlbumArtworkView.swift */,
+			);
+			path = Views;
 			sourceTree = "<group>";
 		};
 		9821EA7F469BAA8A8F9772A8 /* Dependencies */ = {
@@ -282,6 +293,7 @@
 				7C8D9E0F1A2B3C4D5E6F7081 /* ModeSelectionView.swift in Sources */,
 				6AA2C7F62E2E3AF4AFB831A1 /* HostFeature.swift in Sources */,
 				3C6D8F2A1B4E7C9D0F1A2B3C /* HostView.swift in Sources */,
+				C1D2E3F405162738495A6B7C /* AlbumArtworkView.swift in Sources */,
 				4D2C1B0A9F8E7D6C5B4A3928 /* GuestFeature.swift in Sources */,
 				5E6F7081920A1B2C3D4E5F60 /* GuestView.swift in Sources */,
 				7A8B9C0D1E2F3A4B5C6D7E8F /* MusicKitClient.swift in Sources */,

--- a/ios/DemocracyDJ/Features/Host/HostView.swift
+++ b/ios/DemocracyDJ/Features/Host/HostView.swift
@@ -14,18 +14,13 @@ struct HostView: View {
             // MARK: - Top Section: Now Playing (60% approx via layoutPriority)
             VStack(spacing: 20) {
                 if let song = store.nowPlaying {
-                    // Artwork Placeholder
-                    Rectangle()
-                        .fill(Color.secondary.opacity(0.3))
-                        .aspectRatio(1, contentMode: .fit)
-                        .overlay {
-                            Image(systemName: "music.note")
-                                .font(.system(size: 60))
-                                .foregroundStyle(.secondary)
-                        }
-                        .cornerRadius(12)
-                        .padding(.horizontal, 40)
-                        .accessibilityLabel("Album artwork for \(song.title)")
+                    AlbumArtworkView(
+                        url: song.albumArtURL,
+                        title: song.title,
+                        size: 300,
+                        cornerRadius: 12
+                    )
+                    .padding(.horizontal, 40)
 
                     VStack(spacing: 8) {
                         Text(song.title)

--- a/ios/DemocracyDJ/Views/AlbumArtworkView.swift
+++ b/ios/DemocracyDJ/Views/AlbumArtworkView.swift
@@ -1,0 +1,79 @@
+import SwiftUI
+
+struct AlbumArtworkView: View {
+    let url: URL?
+    let title: String
+    let size: CGFloat
+    let cornerRadius: CGFloat
+
+    init(
+        url: URL?,
+        title: String,
+        size: CGFloat = 300,
+        cornerRadius: CGFloat = 12
+    ) {
+        self.url = url
+        self.title = title
+        self.size = size
+        self.cornerRadius = cornerRadius
+    }
+
+    var body: some View {
+        content
+            .frame(width: size, height: size)
+            .clipShape(RoundedRectangle(cornerRadius: cornerRadius, style: .continuous))
+            .accessibilityLabel("Album artwork for \(title)")
+    }
+
+    @ViewBuilder
+    private var content: some View {
+        if let url {
+            AsyncImage(url: url) { phase in
+                switch phase {
+                case .empty:
+                    placeholder
+                        .overlay(ProgressView())
+                case .success(let image):
+                    image
+                        .resizable()
+                        .scaledToFill()
+                case .failure:
+                    placeholder
+                @unknown default:
+                    placeholder
+                }
+            }
+        } else {
+            placeholder
+        }
+    }
+
+    private var placeholder: some View {
+        Rectangle()
+            .fill(Color.secondary.opacity(0.3))
+            .overlay {
+                Image(systemName: "music.note")
+                    .font(.system(size: size * 0.2))
+                    .foregroundStyle(.secondary)
+            }
+    }
+}
+
+#Preview {
+    VStack(spacing: 24) {
+        AlbumArtworkView(
+            url: URL(string: "https://picsum.photos/300"),
+            title: "Preview Song",
+            size: 180,
+            cornerRadius: 16
+        )
+
+        AlbumArtworkView(
+            url: nil,
+            title: "Placeholder Song",
+            size: 180,
+            cornerRadius: 16
+        )
+    }
+    .padding()
+}


### PR DESCRIPTION
## Summary
- add reusable AlbumArtworkView with AsyncImage and a standalone preview
- render now playing artwork using Song.albumArtURL
- keep placeholders for loading and failure states

Closes #61.