### PR TITLE
Host can remove songs from queue

### DIFF
--- a/ios/DemocracyDJ/Features/Host/HostView.swift
+++ b/ios/DemocracyDJ/Features/Host/HostView.swift
@@ -231,6 +231,20 @@ struct HostView: View {
                         .padding(.vertical, 4)
                         .listRowSeparator(.hidden)
                         .accessibilityIdentifier("song_row_\(item.id)")
+                        .swipeActions(edge: .trailing, allowsFullSwipe: true) {
+                            Button(role: .destructive) {
+                                store.send(.removeSongTapped(id: item.id))
+                            } label: {
+                                Label("Remove", systemImage: "trash")
+                            }
+                        }
+                        .contextMenu {
+                            Button(role: .destructive) {
+                                store.send(.removeSongTapped(id: item.id))
+                            } label: {
+                                Label("Remove from Queue", systemImage: "trash")
+                            }
+                        }
                     }
                 }
                 .listStyle(.plain)


### PR DESCRIPTION
## Summary
- add host confirmation and removal flow for queue items
- add swipe and context menu remove actions in HostView
- add HostFeature tests for removal scenarios

Closes #73.